### PR TITLE
Fix deprecated syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install ome-ansible-molecule-dependencies
 
   # Check ansible version
   - ansible --version
@@ -24,6 +24,7 @@ install:
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - ansible-lint tests/test.yml
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Create OMERO user accounts and groups
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:

--- a/tasks/groups.yml
+++ b/tasks/groups.yml
@@ -14,7 +14,7 @@
     -q
     --style json
   register: groupcmd
-  always_run: yes
+  check_mode: no
   changed_when: False
 
 - name: omero user | set group list var
@@ -33,7 +33,7 @@
     {{ item.name | quote }}
     --type {{ item.type }}
   when: >
-    {{ omero_group_list | selectattr('name', 'equalto', item.name) |
-      list | length }} < 1
+    (omero_group_list | selectattr('name', 'equalto', item.name) |
+      list | length) < 1
   with_items:
   - "{{ omero_group_create }}"

--- a/tasks/reset-password.yml
+++ b/tasks/reset-password.yml
@@ -13,9 +13,9 @@
        selectattr('login', 'equalto', item.login) | first).id }}
     {{ item.password | quote }}
   when: >
-    {{ omero_user_list | selectattr('login', 'equalto', item.login) |
-      list | length }} > 0 and
-    {{ item.force | default(False) }}
+    ((omero_user_list | selectattr('login', 'equalto', item.login) |
+      list | length ) > 0) and
+    (item.force | default(False))
   with_items:
   - "{{ omero_user_create }}"
   register: pwdupdate
@@ -28,7 +28,7 @@
     -d {{ omero_user_dbname }}
     -w -c
     {{ item.stdout | quote }}
-  when: "{{ item | changed }}"
+  when: "item | changed"
   with_items: "{{ pwdupdate.results }}"
   environment:
     PGPASSWORD: "{{ omero_user_dbpassword }}"

--- a/tasks/reset-root-password.yml
+++ b/tasks/reset-root-password.yml
@@ -10,6 +10,9 @@
     --user-id 0
     {{ omero_user_reset_root_password | quote }}
   register: rootpwdupdate
+  # TODO: Is there a way to make this idempotent?
+  tags:
+    - skip_ansible_lint
 
 # WARNING: this will always run
 - name: omero user | force reset omero root password

--- a/tasks/reset-root-password.yml
+++ b/tasks/reset-root-password.yml
@@ -23,4 +23,4 @@
   environment:
     PGPASSWORD: "{{ omero_user_dbpassword }}"
   # This conditional ensures this task won't fail in check-mode
-  when: "{{ rootpwdupdate | changed }}"
+  when: "rootpwdupdate | changed"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -14,7 +14,7 @@
     -q
     --style json
   register: usercmd
-  always_run: yes
+  check_mode: no
   changed_when: False
 
 - name: omero user | set user list var
@@ -36,7 +36,7 @@
     --userpassword {{ item.password | quote }}
     {{ item.groups }}
   when: >
-    {{ omero_user_list | selectattr('login', 'equalto', item.login) |
-      list | length }} < 1
+    (omero_user_list | selectattr('login', 'equalto', item.login) |
+      list | length) < 1
   with_items:
   - "{{ omero_user_create }}"


### PR DESCRIPTION
Also adds an ansible-lint check (with a TODO) in the absence of a full molecule test.