### PR TITLE
omero_user_bin_omero now matches the OMERO.server default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Role Variables
 All variables are optional, see `defaults/main.yml`
 
 Create OMERO user accounts and groups:
-- `omero_user_bin_omero`: The full path to `bin/omero` application, default `/home/omero/OMERO.server/bin/omero`
+- `omero_user_bin_omero`: The full path to `bin/omero` application, default `/opt/omero/server/OMERO.server/bin/omero`
 - `omero_user_system`: Run the `omero` CLI as this user, default `omero` (must not be `root`)
 - `omero_user_admin_user`: Login to OMERO as this admin user, default `root`
 - `omero_user_admin_pass`: Password for `omero_user_admin_user`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for roles/omero-user
 
-omero_user_bin_omero: /home/omero/OMERO.server/bin/omero
+omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
 omero_user_system: omero
 omero_user_admin_user: root
 omero_user_admin_pass: omero


### PR DESCRIPTION
This means it's no longer necessary to define `omero_user_bin_omero` in your playbook if you're running on the same server as OMERO.server.

I'm currently undecided on whether to use this as an opportunity to refactor this role.